### PR TITLE
Fix Tanstack provider case

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { TanstackQueryProvider } from '@/providers';
+import { TanStackQueryProvider } from '@/providers';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -28,7 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <TanstackQueryProvider>{children}</TanstackQueryProvider>
+        <TanStackQueryProvider>{children}</TanStackQueryProvider>
       </body>
     </html>
   );

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -1,1 +1,1 @@
-export * from "./tanstack-query-provider";
+export { TanStackQueryProvider } from "./tanstack-query-provider";

--- a/providers/tanstack-query-provider.tsx
+++ b/providers/tanstack-query-provider.tsx
@@ -6,7 +6,7 @@ import { ReactNode } from "react";
 
 const queryClient = new QueryClient();
 
-export const TanstackQueryProvider = ({
+export const TanStackQueryProvider = ({
   children,
 }: {
   children: ReactNode


### PR DESCRIPTION
## Summary
- rename `TanstackQueryProvider` to `TanStackQueryProvider`
- update exports and imports

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3a8a5d88324bcde778cbc9c8645