### PR TITLE
Add button test

### DIFF
--- a/components/ui/__tests__/button.test.tsx
+++ b/components/ui/__tests__/button.test.tsx
@@ -1,0 +1,11 @@
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Button } from '../button';
+
+describe('Button', () => {
+  it('applies solid variant classes', () => {
+    const { getByRole } = render(<Button variant="solid">Test</Button>);
+    const button = getByRole('button');
+    expect(button).toHaveClass('bg-blue-600', 'text-white', 'hover:bg-blue-700');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,8 @@ const dirname =
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
     workspace: [
       {
         extends: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add Vitest script to package.json
- configure Vitest with jsdom environment
- add global Vitest setup importing `@testing-library/jest-dom`
- create Button unit test using React Testing Library

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3c8c1fc8324bb9acceae268b5f2