### PR TITLE
Add basic Korean/English i18n setup

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
-import './globals.css';
+import '../globals.css';
 import { TanStackQueryProvider } from '@/providers';
 
 const geistSans = Geist({
@@ -20,11 +20,13 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  params,
 }: Readonly<{
   children: React.ReactNode;
+  params: { locale: string };
 }>) {
   return (
-    <html lang='en'>
+    <html lang={params.locale}>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -4,6 +4,8 @@
 import { useQuery } from '@tanstack/react-query';
 import axiosInstance from '@/lib/axiosInstance';
 import { Button } from '@/components/ui/button';
+import { useParams } from 'next/navigation';
+import { getMessages } from '@/lib/i18n';
 
 interface Todo {
   userId: number;
@@ -13,6 +15,9 @@ interface Todo {
 }
 
 export default function Home() {
+  const params = useParams();
+  const locale = (params.locale as string) || 'ko';
+  const t = getMessages(locale);
   const { data, isLoading, error } = useQuery<Todo[], Error>({
     queryKey: ['test'],
     queryFn: () =>
@@ -25,14 +30,14 @@ export default function Home() {
 
   return (
     <div className='flex min-h-screen flex-col items-center justify-center gap-16 p-8 pb-20 font-[family-name:var(--font-geist-sans)] sm:p-20'>
-      <Button color='red'>Button</Button>
+      <Button color='red'>{t.button}</Button>
       <div className='w-full max-w-md'>
         <h1 className='text-cool-gray-500 mb-4 text-center text-2xl font-semibold sm:text-left'>
-          Todos
+          {t.todos}
         </h1>
-        {isLoading && <p className='text-center'>Loading...</p>}
+        {isLoading && <p className='text-center'>{t.loading}</p>}
         {error && (
-          <p className='text-center text-red-500'>Error: {error.message}</p>
+          <p className='text-center text-red-500'>{t.error}{error.message}</p>
         )}
         {data && (
           <ul className='list-disc space-y-2 pl-5'>

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,20 @@
+export type Locale = 'ko' | 'en';
+
+export const messages = {
+  ko: {
+    button: '버튼',
+    todos: '할 일',
+    loading: '로딩 중...',
+    error: '오류: ',
+  },
+  en: {
+    button: 'Button',
+    todos: 'Todos',
+    loading: 'Loading...',
+    error: 'Error: ',
+  },
+} as const;
+
+export function getMessages(locale: string) {
+  return messages[locale as Locale] ?? messages.ko;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  i18n: {
+    locales: ['ko', 'en'],
+    defaultLocale: 'ko',
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- configure Next.js `i18n` for Korean(default) and English
- restructure pages under `/[locale]` and set html `lang`
- add simple translation helper and use it on the home page

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684125825e9883249d3b6c42d99e8da3