### PR TITLE
Fix React type imports for layouts

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { type ReactNode } from 'react';
 import '../globals.css';
 import { TanStackQueryProvider } from '@/providers';
 
@@ -22,7 +23,7 @@ export default function RootLayout({
   children,
   params,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
   params: { locale: string };
 }>) {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { type ReactNode } from 'react';
 import './globals.css';
 import { TanStackQueryProvider } from '@/providers';
 
@@ -21,7 +22,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang='en'>


### PR DESCRIPTION
## Summary
- clean up React type usage in layout files
- import ReactNode from React to avoid ts2686

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68412df848188324a8976aaf3f8e0598