### PR TITLE
Fix Next.js i18n warning

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -1,0 +1,6 @@
+export const i18n = {
+  defaultLocale: 'ko',
+  locales: ['ko', 'en'],
+} as const;
+
+export type Locale = (typeof i18n)['locales'][number];

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,5 @@
 import type { NextConfig } from 'next';
-import { i18n } from './next-i18next.config';
 
-const nextConfig: NextConfig = {
-  i18n,
-};
+const nextConfig: NextConfig = {};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- remove deprecated i18n setting from `next.config.ts`
- create `i18n.ts` file for locale configuration

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684132fa55248324af9f0070b8c0366c